### PR TITLE
Fix pytest warnings

### DIFF
--- a/html5lib/tests/conftest.py
+++ b/html5lib/tests/conftest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os.path
 import sys
 
@@ -99,10 +98,10 @@ def pytest_collect_file(path, parent):
 
     if _tree_construction in dir_and_parents:
         if path.ext == ".dat":
-            return TreeConstructionFile(path, parent)
+            return TreeConstructionFile.from_parent(parent, fspath=path)
     elif _tokenizer in dir_and_parents:
         if path.ext == ".test":
-            return TokenizerFile(path, parent)
+            return TokenizerFile.from_parent(parent, fspath=path)
     elif _sanitizer_testdata in dir_and_parents:
         if path.ext == ".dat":
-            return SanitizerFile(path, parent)
+            return SanitizerFile.from_parent(parent, fspath=path)

--- a/html5lib/tests/sanitizer.py
+++ b/html5lib/tests/sanitizer.py
@@ -13,14 +13,16 @@ class SanitizerFile(pytest.File):
         with codecs.open(str(self.fspath), "r", encoding="utf-8") as fp:
             tests = json.load(fp)
         for i, test in enumerate(tests):
-            yield SanitizerTest(str(i), self, test=test)
+            yield SanitizerTest.from_parent(self, name=str(i), test=test)
 
 
 class SanitizerTest(pytest.Item):
-    def __init__(self, name, parent, test):
-        super(SanitizerTest, self).__init__(name, parent)
-        self.obj = lambda: 1  # this is to hack around skipif needing a function!
-        self.test = test
+    @classmethod
+    def from_parent(cls, parent, *, name, test):
+        node = super().from_parent(parent, name=name)
+        node.obj = lambda: 1  # this is to hack around skipif needing a function!
+        node.test = test
+        return node
 
     def runtest(self):
         input = self.test["input"]

--- a/html5lib/tests/support.py
+++ b/html5lib/tests/support.py
@@ -7,6 +7,7 @@ import sys
 import codecs
 import glob
 import xml.sax.handler
+from collections import OrderedDict
 
 base_path = os.path.split(__file__)[0]
 
@@ -19,7 +20,8 @@ from html5lib import treebuilders, treewalkers, treeadapters  # noqa
 del base_path
 
 # Build a dict of available trees
-treeTypes = {}
+# It is ordered so that callers need not sort it to get stable ordering.
+treeTypes = OrderedDict()
 
 # DOM impls
 treeTypes["DOM"] = {

--- a/html5lib/tests/test_treewalkers.py
+++ b/html5lib/tests/test_treewalkers.py
@@ -40,7 +40,7 @@ def test_all_tokens():
         {'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'body'},
         {'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'html'}
     ]
-    for _, treeCls in sorted(treeTypes.items()):
+    for _, treeCls in treeTypes.items():
         if treeCls is None:
             continue
         p = html5parser.HTMLParser(tree=treeCls["builder"])

--- a/html5lib/tests/tree_construction.py
+++ b/html5lib/tests/tree_construction.py
@@ -36,7 +36,7 @@ class TreeConstructionTest(pytest.Collector):
         return node
 
     def collect(self):
-        for treeName, treeAPIs in sorted(treeTypes.items()):
+        for treeName, treeAPIs in treeTypes.items():
             yield from self._getParserTests(treeName, treeAPIs)
             yield self._getTreeWalkerTest(treeName, treeAPIs)
 

--- a/html5lib/tests/tree_construction.py
+++ b/html5lib/tests/tree_construction.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, unicode_literals
 
-import itertools
 import re
 import warnings
 from difflib import unified_diff
@@ -26,21 +25,24 @@ class TreeConstructionFile(pytest.File):
     def collect(self):
         tests = TestData(str(self.fspath), "data")
         for i, test in enumerate(tests):
-            yield TreeConstructionTest(str(i), self, testdata=test)
+            yield TreeConstructionTest.from_parent(self, name=str(i), testdata=test)
 
 
 class TreeConstructionTest(pytest.Collector):
-    def __init__(self, name, parent=None, config=None, session=None, testdata=None):
-        super(TreeConstructionTest, self).__init__(name, parent, config, session)
-        self.testdata = testdata
+    @classmethod
+    def from_parent(cls, parent, *, name, testdata=None):
+        node = super().from_parent(parent, name=name)
+        node.testdata = testdata
+        return node
 
     def collect(self):
         for treeName, treeAPIs in sorted(treeTypes.items()):
-            for x in itertools.chain(self._getParserTests(treeName, treeAPIs),
-                                     self._getTreeWalkerTests(treeName, treeAPIs)):
-                yield x
+            yield from self._getParserTests(treeName, treeAPIs)
+            yield self._getTreeWalkerTest(treeName, treeAPIs)
 
     def _getParserTests(self, treeName, treeAPIs):
+        # This has the effect of skipping the genshi implementation, which
+        # lacks a parser.
         if treeAPIs is not None and "adapter" in treeAPIs:
             return
         for namespaceHTMLElements in (True, False):
@@ -48,26 +50,25 @@ class TreeConstructionTest(pytest.Collector):
                 nodeid = "%s::parser::namespaced" % treeName
             else:
                 nodeid = "%s::parser::void-namespace" % treeName
-            item = ParserTest(nodeid,
-                              self,
-                              self.testdata,
-                              treeAPIs["builder"] if treeAPIs is not None else None,
-                              namespaceHTMLElements)
+            item = ParserTest.from_parent(
+                self,
+                name=nodeid,
+                test=self.testdata,
+                treeClass=treeAPIs["builder"] if treeAPIs is not None else None,
+                namespaceHTMLElements=namespaceHTMLElements,
+            )
             item.add_marker(getattr(pytest.mark, treeName))
             item.add_marker(pytest.mark.parser)
             if namespaceHTMLElements:
                 item.add_marker(pytest.mark.namespaced)
             yield item
 
-    def _getTreeWalkerTests(self, treeName, treeAPIs):
+    def _getTreeWalkerTest(self, treeName, treeAPIs):
         nodeid = "%s::treewalker" % treeName
-        item = TreeWalkerTest(nodeid,
-                              self,
-                              self.testdata,
-                              treeAPIs)
+        item = TreeWalkerTest.from_parent(self, name=nodeid, test=self.testdata, treeAPIs=treeAPIs)
         item.add_marker(getattr(pytest.mark, treeName))
         item.add_marker(pytest.mark.treewalker)
-        yield item
+        return item
 
 
 def convertTreeDump(data):
@@ -78,11 +79,13 @@ namespaceExpected = re.compile(r"^(\s*)<(\S+)>", re.M).sub
 
 
 class ParserTest(pytest.Item):
-    def __init__(self, name, parent, test, treeClass, namespaceHTMLElements):
-        super(ParserTest, self).__init__(name, parent)
-        self.test = test
-        self.treeClass = treeClass
-        self.namespaceHTMLElements = namespaceHTMLElements
+    @classmethod
+    def from_parent(cls, parent, *, name, test, treeClass, namespaceHTMLElements):
+        node = super().from_parent(parent, name=name)
+        node.test = test
+        node.treeClass = treeClass
+        node.namespaceHTMLElements = namespaceHTMLElements
+        return node
 
     def runtest(self):
         if self.treeClass is None:
@@ -143,10 +146,12 @@ class ParserTest(pytest.Item):
 
 
 class TreeWalkerTest(pytest.Item):
-    def __init__(self, name, parent, test, treeAPIs):
-        super(TreeWalkerTest, self).__init__(name, parent)
-        self.test = test
-        self.treeAPIs = treeAPIs
+    @classmethod
+    def from_parent(cls, parent, *, name, test, treeAPIs):
+        node = super().from_parent(parent, name=name)
+        node.test = test
+        node.treeAPIs = treeAPIs
+        return node
 
     def runtest(self):
         if self.treeAPIs is None:


### PR DESCRIPTION
pytest has deprecated direct calls to the Node constructor:

    html5lib/tests/conftest.py:108
      .../html5lib/tests/conftest.py:108: PytestDeprecationWarning: direct construction of SanitizerFile has been deprecated, please use SanitizerFile.from_parent
        return SanitizerFile(path, parent)

    html5lib/tests/conftest.py:105: 14 tests with warnings
      .../html5lib/tests/conftest.py:105: PytestDeprecationWarning: direct construction of TokenizerFile has been deprecated, please use TokenizerFile.from_parent
        return TokenizerFile(path, parent)

    html5lib/tests/conftest.py:102: 56 tests with warnings
      .../html5lib/tests/conftest.py:102: PytestDeprecationWarning: direct construction of TreeConstructionFile has been deprecated, please use TreeConstructionFile.from_parent
        return TreeConstructionFile(path, parent)

    html5lib/tests/sanitizer.py:16: 72 tests with warnings
      .../html5lib/tests/sanitizer.py:16: PytestDeprecationWarning: direct construction of SanitizerTest has been deprecated, please use SanitizerTest.from_parent
        yield SanitizerTest(str(i), self, test=test)

    html5lib/tests/tokenizer.py:195: 6804 tests with warnings
      .../html5lib/tests/tokenizer.py:195: PytestDeprecationWarning: direct construction of TokenizerTestCollector has been deprecated, please use TokenizerTestCollector.from_parent
        yield TokenizerTestCollector(str(i), self, testdata=test)

    html5lib/tests/tokenizer.py:213: 7030 tests with warnings
      .../html5lib/tests/tokenizer.py:213: PytestDeprecationWarning: direct construction of TokenizerTest has been deprecated, please use TokenizerTest.from_parent
        initialState)

    html5lib/tests/conftest.py:102: 56 tests with warnings
      .../html5lib/tests/conftest.py:102: PytestDeprecationWarning: direct construction of TreeConstructionFile has been deprecated, please use TreeConstructionFile.from_parent
        return TreeConstructionFile(path, parent)

    html5lib/tests/tree_construction.py:29: 1704 tests with warnings
      .../html5lib/tests/tree_construction.py:29: PytestDeprecationWarning: direct construction of TreeConstructionTest has been deprecated, please use TreeConstructionTest.from_parent
        yield TreeConstructionTest(str(i), self, testdata=test)

    html5lib/tests/tree_construction.py:55: 13632 tests with warnings
      ...r/html5lib/tests/tree_construction.py:55: PytestDeprecationWarning: direct construction of ParserTest has been deprecated, please use ParserTest.from_parent
        namespaceHTMLElements)

    html5lib/tests/tree_construction.py:67: 8520 tests with warnings
      .../html5lib/tests/tree_construction.py:67: PytestDeprecationWarning: direct construction of TreeWalkerTest has been deprecated, please use TreeWalkerTest.from_parent
        treeAPIs)


Resolve these by adding from_parent() constructors.