### PR TITLE
Remove cElementTree infrastructure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,6 @@ or:
   document = html5lib.parse("<p>Hello World!")
 
 By default, the ``document`` will be an ``xml.etree`` element instance.
-Whenever possible, html5lib chooses the accelerated ``ElementTree``
-implementation (i.e. ``xml.etree.cElementTree`` on Python 2.x).
 
 Two other tree types are supported: ``xml.dom.minidom`` and
 ``lxml.etree``. To use an alternative format, specify the name of

--- a/doc/movingparts.rst
+++ b/doc/movingparts.rst
@@ -16,9 +16,7 @@ The parser reads HTML by tokenizing the content and building a tree that
 the user can later access. html5lib can build three types of trees:
 
 * ``etree`` - this is the default; builds a tree based on :mod:`xml.etree`,
-  which can be found in the standard library. Whenever possible, the
-  accelerated ``ElementTree`` implementation (i.e.
-  ``xml.etree.cElementTree`` on Python 2.x) is used.
+  which can be found in the standard library.
 
 * ``dom`` - builds a tree based on :mod:`xml.dom.minidom`.
 

--- a/html5lib/_utils.py
+++ b/html5lib/_utils.py
@@ -1,9 +1,8 @@
 from types import ModuleType
 from collections.abc import Mapping
-import xml.etree.ElementTree as default_etree
 
 
-__all__ = ["default_etree", "MethodDispatcher", "isSurrogatePair",
+__all__ = ["MethodDispatcher", "isSurrogatePair",
            "surrogatePairToCodepoint", "moduleFactoryFactory",
            "supports_lone_surrogates"]
 

--- a/html5lib/tests/conftest.py
+++ b/html5lib/tests/conftest.py
@@ -74,17 +74,6 @@ def pytest_configure(config):
                                 if not installed:
                                     msgs.append("Need %s" % spec)
 
-        # Check cElementTree
-        import xml.etree.ElementTree as ElementTree
-
-        try:
-            import xml.etree.cElementTree as cElementTree
-        except ImportError:
-            msgs.append("cElementTree unable to be imported")
-        else:
-            if cElementTree.Element is ElementTree.Element:
-                msgs.append("cElementTree is just an alias for ElementTree")
-
     if msgs:
         pytest.exit("\n".join(msgs))
 

--- a/html5lib/tests/support.py
+++ b/html5lib/tests/support.py
@@ -37,20 +37,6 @@ treeTypes['ElementTree'] = {
 }
 
 try:
-    import xml.etree.cElementTree as cElementTree  # noqa
-except ImportError:
-    treeTypes['cElementTree'] = None
-else:
-    # On Python 3.3 and above cElementTree is an alias, don't run them twice.
-    if cElementTree.Element is ElementTree.Element:
-        treeTypes['cElementTree'] = None
-    else:
-        treeTypes['cElementTree'] = {
-            "builder": treebuilders.getTreeBuilder("etree", cElementTree, fullTree=True),
-            "walker": treewalkers.getTreeWalker("etree", cElementTree)
-        }
-
-try:
     import lxml.etree as lxml  # noqa
 except ImportError:
     treeTypes['lxml'] = None

--- a/html5lib/tests/test_treewalkers.py
+++ b/html5lib/tests/test_treewalkers.py
@@ -50,18 +50,6 @@ def test_all_tokens():
             assert expectedToken == outputToken
 
 
-def set_attribute_on_first_child(docfrag, name, value, treeName):
-    """naively sets an attribute on the first child of the document
-    fragment passed in"""
-    setter = {'ElementTree': lambda d: d[0].set,
-              'DOM': lambda d: d.firstChild.setAttribute}
-    setter['cElementTree'] = setter['ElementTree']
-    try:
-        setter.get(treeName, setter['DOM'])(docfrag)(name, value)
-    except AttributeError:
-        setter['ElementTree'](docfrag)(name, value)
-
-
 @pytest.mark.parametrize("tree,char", itertools.product(sorted(treeTypes.items()), ["x", "\u1234"]))
 def test_fragment_single_char(tree, char):
     expected = [

--- a/html5lib/treebuilders/__init__.py
+++ b/html5lib/treebuilders/__init__.py
@@ -31,8 +31,6 @@ implement several things:
 
 from __future__ import absolute_import, division, unicode_literals
 
-from .._utils import default_etree
-
 treeBuilderCache = {}
 
 
@@ -78,7 +76,7 @@ def getTreeBuilder(treeType, implementation=None, **kwargs):
         elif treeType == "etree":
             from . import etree
             if implementation is None:
-                implementation = default_etree
+                from xml.etree import ElementTree as implementation
             # NEVER cache here, caching is done in the etree submodule
             return etree.getETreeModule(implementation, **kwargs).TreeBuilder
         else:

--- a/html5lib/treebuilders/__init__.py
+++ b/html5lib/treebuilders/__init__.py
@@ -45,14 +45,12 @@ def getTreeBuilder(treeType, implementation=None, **kwargs):
         * "dom" - A generic builder for DOM implementations, defaulting to a
           xml.dom.minidom based implementation.
         * "etree" - A generic builder for tree implementations exposing an
-          ElementTree-like interface, defaulting to xml.etree.cElementTree if
-          available and xml.etree.ElementTree if not.
+          ElementTree-like interface, defaulting to `xml.etree.ElementTree`
         * "lxml" - A etree-based builder for lxml.etree, handling limitations
           of lxml's implementation.
 
     :arg implementation: (Currently applies to the "etree" and "dom" tree
         types). A module implementing the tree type e.g. xml.etree.ElementTree
-        or xml.etree.cElementTree.
 
     :arg kwargs: Any additional options to pass to the TreeBuilder when
         creating it.

--- a/html5lib/treewalkers/__init__.py
+++ b/html5lib/treewalkers/__init__.py
@@ -26,13 +26,13 @@ def getTreeWalker(treeType, implementation=None, **kwargs):
 
         * "dom": The xml.dom.minidom DOM implementation
         * "etree": A generic walker for tree implementations exposing an
-          elementtree-like interface (known to work with ElementTree,
-          cElementTree and lxml.etree).
+          elementtree-like interface (known to work with `xml.etree.ElementTree`
+          and :mod:`lxml.etree`).
         * "lxml": Optimized walker for lxml.etree
         * "genshi": a Genshi stream
 
     :arg implementation: A module implementing the tree type e.g.
-        xml.etree.ElementTree or cElementTree (Currently applies to the "etree"
+        `xml.etree.ElementTree` (currently applies to the "etree"
         tree type only).
 
     :arg kwargs: keyword arguments passed to the etree walker--for other

--- a/html5lib/treewalkers/__init__.py
+++ b/html5lib/treewalkers/__init__.py
@@ -11,7 +11,6 @@ returns an iterator which generates tokens.
 from __future__ import absolute_import, division, unicode_literals
 
 from .. import constants
-from .._utils import default_etree
 
 __all__ = ["getTreeWalker", "pprint"]
 
@@ -56,7 +55,7 @@ def getTreeWalker(treeType, implementation=None, **kwargs):
         elif treeType == "etree":
             from . import etree
             if implementation is None:
-                implementation = default_etree
+                from xml.etree import ElementTree as implementation
             # XXX: NEVER cache here, caching is done in the etree submodule
             return etree.getETreeModule(implementation, **kwargs).TreeWalker
     return treeWalkerCache.get(treeType)

--- a/parse.py
+++ b/parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Parse a document to a tree, with optional profiling
 """
@@ -10,7 +10,6 @@ import traceback
 from html5lib import html5parser
 from html5lib import treebuilders, serializer, treewalkers
 from html5lib import constants
-from html5lib import _utils
 
 
 def parse():
@@ -115,7 +114,8 @@ def printOutput(parser, document, opts):
                 import lxml.etree
                 sys.stdout.write(lxml.etree.tostring(document, encoding="unicode"))
             elif tb == "etree":
-                sys.stdout.write(_utils.default_etree.tostring(document, encoding="unicode"))
+                from xml.etree import ElementTree
+                sys.stdout.write(ElementTree.tostring(document, encoding="unicode"))
         elif opts.tree:
             if not hasattr(document, '__getitem__'):
                 document = [document]

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,6 @@ xfail_strict = true
 markers =
     DOM: mark a test as a DOM tree test
     ElementTree: mark a test as a ElementTree tree test
-    cElementTree: mark a test as a cElementTree tree test
     lxml: mark a test as a lxml tree test
     genshi: mark a test as a genshi tree test
     parser: mark a test as a parser test


### PR DESCRIPTION
Since cElementTree isn't a separate thing in Python 3 all the associated plumbing can be removed.