### PR TITLE
Remove <event-source> support

### DIFF
--- a/html5lib/constants.py
+++ b/html5lib/constants.py
@@ -559,7 +559,6 @@ headingElements = (
 voidElements = frozenset([
     "base",
     "command",
-    "event-source",
     "link",
     "meta",
     "hr",

--- a/html5lib/filters/sanitizer.py
+++ b/html5lib/filters/sanitizer.py
@@ -49,7 +49,6 @@ allowed_elements = frozenset((
     (namespaces['html'], 'dl'),
     (namespaces['html'], 'dt'),
     (namespaces['html'], 'em'),
-    (namespaces['html'], 'event-source'),
     (namespaces['html'], 'fieldset'),
     (namespaces['html'], 'figcaption'),
     (namespaces['html'], 'figure'),


### PR DESCRIPTION
Per https://github.com/html5lib/html5lib-python/issues/203 this element no longer exists. The `<keygen>` and `<menuitem>` elements mentioned there have also been removed from the spec, so there is no need to add them.