### PR TITLE
Always return a full tree

### DIFF
--- a/changelog.d/25.removal.rst
+++ b/changelog.d/25.removal.rst
@@ -1,0 +1,1 @@
+The etree and lxml tree builders now default to returning the full tree. This means that the `parse()` function now returns a synthetic document root element rather than the root `<html>` element.

--- a/html5lib/tests/support.py
+++ b/html5lib/tests/support.py
@@ -32,7 +32,7 @@ treeTypes["DOM"] = {
 # ElementTree impls
 import xml.etree.ElementTree as ElementTree  # noqa
 treeTypes['ElementTree'] = {
-    "builder": treebuilders.getTreeBuilder("etree", ElementTree, fullTree=True),
+    "builder": treebuilders.getTreeBuilder("etree", ElementTree),
     "walker": treewalkers.getTreeWalker("etree")
 }
 

--- a/html5lib/tests/test_parser2.py
+++ b/html5lib/tests/test_parser2.py
@@ -34,17 +34,13 @@ def test_namespace_html_elements_1_dom():
 
 
 def test_namespace_html_elements_0_etree():
-    doc = parse("<html></html>",
-                treebuilder="etree",
-                namespaceHTMLElements=True)
-    assert doc.tag == "{%s}html" % (namespaces["html"],)
+    [root] = parse("<html></html>", treebuilder="etree", namespaceHTMLElements=True)
+    assert root.tag == "{%s}html" % (namespaces["html"],)
 
 
 def test_namespace_html_elements_1_etree():
-    doc = parse("<html></html>",
-                treebuilder="etree",
-                namespaceHTMLElements=False)
-    assert doc.tag == "html"
+    [root] = parse("<html></html>", treebuilder="etree", namespaceHTMLElements=False)
+    assert root.tag == "html"
 
 
 def test_unicode_file():

--- a/html5lib/treebuilders/etree.py
+++ b/html5lib/treebuilders/etree.py
@@ -12,7 +12,7 @@ from .._utils import moduleFactoryFactory
 tag_regexp = re.compile("{([^}]*)}(.*)")
 
 
-def getETreeBuilder(ElementTreeImplementation, fullTree=False):
+def getETreeBuilder(ElementTreeImplementation):
     ElementTree = ElementTreeImplementation
     ElementTreeCommentType = ElementTree.Comment("asd").tag
 
@@ -321,14 +321,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
             return testSerializer(element)
 
         def getDocument(self):
-            if fullTree:
-                return self.document._element
-            else:
-                if self.defaultNamespace is not None:
-                    return self.document._element.find(
-                        "{%s}html" % self.defaultNamespace)
-                else:
-                    return self.document._element.find("html")
+            return self.document._element
 
         def getFragment(self):
             return super().getFragment()._element

--- a/html5lib/treebuilders/etree_lxml.py
+++ b/html5lib/treebuilders/etree_lxml.py
@@ -26,7 +26,6 @@ from .. import _ihatexml
 import lxml.etree as etree
 
 
-fullTree = True
 tag_regexp = re.compile("{([^}]*)}(.*)")
 
 comment_type = etree.Comment("asd").tag
@@ -185,8 +184,8 @@ class TreeBuilder(base.TreeBuilder):
     fragmentClass = Document
     implementation = etree
 
-    def __init__(self, namespaceHTMLElements, fullTree=False):
-        builder = etree_builders.getETreeModule(etree, fullTree=fullTree)
+    def __init__(self, namespaceHTMLElements):
+        builder = etree_builders.getETreeModule(etree)
         infosetFilter = self.infosetFilter = _ihatexml.InfosetFilter(preventDoubleDashComments=True)
         self.namespaceHTMLElements = namespaceHTMLElements
 
@@ -284,10 +283,7 @@ class TreeBuilder(base.TreeBuilder):
         return testSerializer(element)
 
     def getDocument(self):
-        if fullTree:
-            return self.document._elementTree
-        else:
-            return self.document._elementTree.getroot()
+        return self.document._elementTree
 
     def getFragment(self):
         fragment = []


### PR DESCRIPTION
The undocumented `fullTree` argument to the etree and lxml tree builders controls whether the tree returns a synthetic document root element ("full tree") or the root element itself (`<html>`). The tests expect the full tree, but the API default was to not do so. This standardizes on the full tree to simplify the implementation, which passed the parameter in a... complicated... way.

Returning the HTML element rather than the full tree is likely more usable, even if lossy, so this should be revisited.